### PR TITLE
added Clinival CADD score validation preprocessing scripts. The R scr…

### DIFF
--- a/gene_based_CADD_score_validator/scripts/R/CGD_analysis.r
+++ b/gene_based_CADD_score_validator/scripts/R/CGD_analysis.r
@@ -1,0 +1,305 @@
+library("stringr")
+library("VariantAnnotation") 
+library("getopt")
+library("ggplot2")
+
+#############
+# multiplot #
+#############
+# Allows for multiplotting based upon the number of columns specified
+# Expects a number of plots to draw.
+#
+multiplot <- function(..., plotlist=NULL, file, cols=1, layout=NULL) {
+  library(grid)
+  
+  # Make a list from the ... arguments and plotlist
+  plots <- c(list(...), plotlist)
+  
+  numPlots = length(plots)
+  
+  # If layout is NULL, then use 'cols' to determine layout
+  if (is.null(layout)) {
+    # Make the panel
+    # ncol: Number of columns of plots
+    # nrow: Number of rows needed, calculated from # of cols
+    layout <- matrix(seq(1, cols * ceiling(numPlots/cols)),
+                     ncol = cols, nrow = ceiling(numPlots/cols))
+  }
+  
+  if (numPlots==1) 
+  {
+    print(plots[[1]])
+    
+  } 
+  else
+  {
+    # Set up the page
+    grid.newpage()
+    pushViewport(viewport(layout = grid.layout(nrow(layout), ncol(layout))))
+    
+    # Make each plot, in the correct location
+    for (i in 1:numPlots) {
+      # Get the i,j matrix positions of the regions that contain this subplot
+      matchidx <- as.data.frame(which(layout == i, arr.ind = TRUE))
+      
+      print(plots[[i]], vp = viewport(layout.pos.row = matchidx$row,
+                                      layout.pos.col = matchidx$col))
+    }
+  }
+}
+
+
+analyse.Gene <- function(gene, vcf, plots, plotout, patient.cadd, max.thresholds){
+  gene.datatable <- as.data.frame(info(vcf)[1:nrow(info(vcf)), 1:11][info(vcf)$GENE_SYMBOL == gene,])
+  colours <- NULL
+  results.df <- data.frame(
+    "gene symbol" = gene
+  )
+  print(gene)
+  #get non pathogenic and pathogenic indici
+  index.benign = which( .02 < gene.datatable["GoNL_AF"] )
+  index.benign = c(index.benign, which(.02 < gene.datatable["Thousand_Genomes_AF"]))
+  index.benign = c(index.benign, which(.02 < gene.datatable["EXAC_AF"]))
+
+  index.pathogenic = which( "5" == gene.datatable["CLINVAR_CLNSIG"] )
+
+  # set all colour labels to unknown 
+ 
+  print(which( "Pathogenic" %in% gene.datatable["CLINVAR_CLNSIG"] ))
+  colours = rep("Unknown", nrow(gene.datatable))
+  
+  validGene<-F
+  
+  for (i in 1:nrow(gene.datatable["CLINVAR_CLNSIG"]))
+  {
+    elt = gene.datatable$CLINVAR_CLNSIG[[i]]
+    if (0 != length(elt))
+    {
+      if (is.element("5", strsplit(elt, "\\|")[[1]])){
+        index.pathogenic = c(index.pathogenic, i)  
+      }
+      else if(is.element("4", strsplit(elt, "\\|")[[1]])){
+        index.pathogenic = c(index.pathogenic, i)
+      }
+      else if(is.element("3", strsplit(elt, "\\|")[[1]])){
+        index.benign = c(index.benign, i )
+      }
+    }
+  } 
+  
+  
+  if(length(index.pathogenic) > 5  & length(index.benign) > 5  & (length(index.benign) + length(index.pathogenic)) > 20){
+    
+    
+    
+    # if there are any indexes found indicating pathogenic variants then set the pathogenic colour labels
+    if(length(index.pathogenic) > 0)
+    {
+      colours[index.pathogenic] <- "Pathogenic"
+    }
+    # if there are any indexes found indicating Benign variants then set the Benign colour labels
+    if(length(index.benign) > 0)
+    {
+      colours[index.benign] <- "Benign"
+    }
+
+    
+    # set colour labels to the gene table
+    gene.datatable$colour <- colours
+    # sort data by cadd score
+    gene.datatable.sorted.cadd.scaled <- gene.datatable[order(unlist(gene.datatable["CADD"])),]
+    
+    for(max.errors in 0:max.thresholds){
+      max.benign.errors <- (length(index.benign) / 100 ) * max.errors
+      max.pathogenic.errors <- (length(index.pathogenic) / 100  ) * max.errors
+
+      cadd.scaled.benign.index <- treshold.benign.calculate(unlist(gene.datatable.sorted.cadd.scaled["colour"]), err.max=max.benign.errors)
+      cadd.scaled.pathogenic.index <- treshold.pathogenic.calculate(unlist(gene.datatable.sorted.cadd.scaled["colour"]), err.max=max.pathogenic.errors)
+
+      benign.cutoff <- unlist(gene.datatable.sorted.cadd.scaled$CADD_SCALED)[cadd.scaled.benign.index]
+      pathogenic.cutoff <- unlist(gene.datatable.sorted.cadd.scaled$CADD_SCALED)[cadd.scaled.pathogenic.index]
+      
+      if (plots){
+        
+        cadd.scaled.plot <- NULL
+        cadd.scaled.plot <- qplot(unlist(gene.datatable.sorted.cadd.scaled["CADD_SCALED"]), xlab="CADD scaled score", ylab="Counts", main=paste("Scaled CADD score distribution permitting", max.errors, "% errors for gene:", gene), fill=factor(unlist(gene.datatable.sorted.cadd.scaled$colour))) + scale_fill_manual(values=c("#009E73", "#D55E00", "#0072B2"))
+        cadd.scaled.plot <- cadd.scaled.plot + geom_vline(xintercept = patient.cadd, colour="red", linetype = "longdash")
+        
+        cadd.scaled.plot <- cadd.scaled.plot + geom_vline(xintercept = unlist(gene.datatable.sorted.cadd.scaled$CADD_SCALED)[cadd.scaled.benign.index], colour="purple")
+        cadd.scaled.plot <- cadd.scaled.plot + geom_vline(xintercept = unlist(gene.datatable.sorted.cadd.scaled$CADD_SCALED)[cadd.scaled.pathogenic.index], colour="orange")
+        cadd.scaled.plot <- cadd.scaled.plot + guides(fill=guide_legend(title="Classification"))
+        # pdf(paste("/Users/molgenis/Desktop/afstuderen/presentatie/figures", gene, max.errors, ".pdf", sep=""),width=15, height=7)
+        
+        plot(cadd.scaled.plot)
+        # dev.off()
+      }
+      
+     
+      if(benign.cutoff < pathogenic.cutoff){
+        
+        validGene = T
+        results.df["Number of pathogenic variants"] = length(index.pathogenic)
+        results.df["Number of benign variants"] = length(index.benign)
+        
+        results.df[paste("pathogenic threshold,", max.errors, "% errors")] <- pathogenic.cutoff
+        results.df[paste("benign threshold,", max.errors, "% errors")] <- benign.cutoff
+        
+        npathogenic.pathogenic.region <- (length(which("Pathogenic" == unlist(gene.datatable.sorted.cadd.scaled$colour)[cadd.scaled.pathogenic.index: length(unlist(gene.datatable.sorted.cadd.scaled$colour))])) / (length(index.benign) + length(index.pathogenic))) * 100
+        npathogenic.benign.region <- (length(which("Pathogenic" == unlist(gene.datatable.sorted.cadd.scaled$colour)[0:cadd.scaled.benign.index])) / (length(index.benign) + length(index.pathogenic))) * 100
+        nbenign.pathogenic.region <- (length(which("Benign" == unlist(gene.datatable.sorted.cadd.scaled$colour)[cadd.scaled.pathogenic.index: length(unlist(gene.datatable.sorted.cadd.scaled$colour))])) / (length(index.benign) + length(index.pathogenic))) * 100
+        nbenign.benign.region <-  (length(which("Benign" == unlist(gene.datatable.sorted.cadd.scaled$colour)[0:cadd.scaled.benign.index]))/ (length(index.benign) + length(index.pathogenic))) * 100
+        
+        results.df[paste("% pathogenic variants in pathogenic region", max.errors, "% errors")] <- npathogenic.pathogenic.region
+        results.df[paste("% benign variants in pathogenic region", max.errors, "% errors")] <- nbenign.pathogenic.region
+        results.df[paste("% pathogenic variants in benign region", max.errors, "% errors")] <- npathogenic.benign.region
+        results.df[paste("% benign variants in benign region", max.errors, "% errors")] <- nbenign.benign.region
+     }
+     else{
+         results.df["Number of pathogenic variants"] = length(index.pathogenic)
+         results.df["Number of benign variants"] = length(index.benign)
+       
+         results.df[paste("pathogenic threshold,", max.errors, "% errors")] <- "N/A"
+         results.df[paste("benign threshold,", max.errors, "% errors")] <- "N/A"
+         
+         results.df[paste("% pathogenic variants in pathogenic region", max.errors, "% errors")] <- "N/A"
+         results.df[paste("% benign variants in pathogenic region", max.errors, "% errors")] <- "N/A"
+         results.df[paste("% pathogenic variants in benign region", max.errors, "% errors")] <- "N/A"
+         results.df[paste("% benign variants in benign region", max.errors, "% errors")] <- "N/A"
+      }
+    
+    }
+    if(validGene){
+      return(results.df)
+    }else{
+      return(NULL)
+    }
+    
+  }
+}
+
+
+treshold.benign.calculate <- function(population, err.max){
+  err.counts = 0
+  index = length(population)
+
+  #check when the first uncertainty occurs
+  for(i in 1:length(population)){
+    if( "Pathogenic" %in% population[i]){
+      err.counts <- err.counts + 1
+      
+      if(err.counts > err.max){
+        index <- i - 1
+        break
+      }
+      
+    }
+  }
+ 
+  if ((index < 1) | (length(index) == 0)){   
+    index <- 1
+  }
+  return(index)
+}
+
+
+treshold.pathogenic.calculate <- function(population, err.max){
+  err.counts = 0
+  index = 1
+
+  #check when the first uncertainty occurs
+  for(i in length(population):1){
+    if("Benign" %in% population[i]){
+      err.counts <- err.counts + 1
+      
+      if(err.counts > err.max){
+        index <- i + 1
+
+        break
+      }
+      
+    }
+  }
+
+  if((index > length(population)) | (length(index) == 0)){
+   
+    index <- length(population)
+  }
+
+  return(index)
+}
+
+
+###################
+# CMDline input check #
+###################
+spec <- matrix(c(
+  'input'     , 'i', 1, "character", "input VCF file annotated using the molgenis annotation software, the following fields are required in the info collumn:        
+  CADD_SCALED               Float 
+  GoNL_GTC                  String
+  GoNL_AF                   String
+  Thousand_Genomes_AF       String
+  EXAC_AF                   String
+  CLINVAR_CLNSIG            String
+  CLINVAR_CLNALLE           String
+  GENE_SYMBOL               String",
+  'out'     , 'o', 1, "character", "ouput CSV path + filename of annotated vcf-file analysis",
+  'plot'    , 'p', 1, "character", "T for generating plot output and F for no plot output, defaults to false",
+  'pout'    , 'q', 1, "character", "Ouput directory to write png graphs of the analysis, every gene will generate 1 plot. gene name will be used as file name",
+  'help'   , 'h', 0, "logical",   "This help",
+  'maxthresholds'     , 't', 1, "integer", "Defines maximum amount of unexpected values permitted to define treshold values in percentages for each class increments by 1%,
+  5 will mean 0%, 1%, 2%, 3%, 4% and 5% permitted unexpected values",
+  'cadd'     , 'c', 1, "double", "Defines CADD scaled score value indicating a patient"
+),ncol=5,byrow=T)
+
+# parse commandline option
+opt = getopt(spec);
+
+# check all arguments are present or help option is present, if needed show usage
+if(!is.null(opt$help) || is.null(opt$input) || is.null(opt$out) || is.null(opt$cadd) || is.null(opt$maxthresholds)){
+  cat(paste(getopt(spec, usage=T),"\n"));
+  q()
+}
+
+# set default plot options if needed
+if (is.null(opt$plot)){
+  opt$plot <- F
+}
+
+# check for plot output dir
+if (opt$plot){
+  if(is.null(opt$pout)){
+    cat(paste(getopt(spec, usage=T),"\n"));
+    q()
+  }
+}
+
+
+##########################
+# annotated VCF analysis #
+##########################
+# start analysis
+vcf.file<-readVcf(opt$input, "hg19")
+genes <- unique(info(vcf.file)$GENE_SYMBOL)
+cat(paste(c("## Starting analysis of: ", opt$input)))
+results.rows.df<-lapply(genes, analyse.Gene, vcf=vcf.file, plots=opt$plot, plotout=opt$pout, max.thresholds=opt$maxthresholds)
+df.results<-do.call("rbind", results.rows.df)
+cat("## Output will be written to: ")
+cat(paste(c(opt$out,"\n"), sep=""))
+write.table(df.results, file = opt$out, sep = "\t", col.names = NA, qmethod = "double")
+cat("#### Done ######\n")
+cat(paste(c("Kept"), nrow(df.results), "out of", length(genes), "genes\n" ))
+
+#test
+vcf<-readVcf("/Users/molgenis/Desktop/Analysis/data/merged.vcf", "hg19")
+#genes <- unique(unlist(info(vcf)$GENE_SYMBOL))
+#length(genes)
+
+#genes <- unique(unlist(info(vcf)$GENE_SYMBOL))
+#results<-lapply(genes[2001:length(genes)], analyse.Gene, vcf=vcf, plots=F, patient.cadd=15, max.thresholds=5)
+#results.df<-do.call("rbind", results)
+#analyse.Gene(gene = "SMPD1", vcf = vcf, plots = T, max.thresholds = 5, patient.cadd = 10)
+
+
+a <- as.data.frame(info(vcf)[1:nrow(info(vcf)), 1:11][info(vcf)$GENE_SYMBOL == "SMPD1",])
+
+which(a$CLINVAR_CLNSIG == "2")

--- a/gene_based_CADD_score_validator/scripts/python/allele_strand_swapper.py
+++ b/gene_based_CADD_score_validator/scripts/python/allele_strand_swapper.py
@@ -1,0 +1,273 @@
+#! /usr/bin/local/python3
+"""
+Author  : Bram Miedema
+Version : 0.1
+date    : 22-September-2015
+
+This script 
+
+This script needs two arguments -o [path_to_output_file]> and a one or more files
+any argument after the options below will be considered file names <two or more vcf batch files to be merged>]
+
+Below is a list of options available:
+    -h [--help] shows this screen
+    -v [--verbose] verbose mode test purpose
+    -o [--output] specifies the output file path and file name e.g /homes/output.vcf
+    -t [--test] enables test run no output file will be created
+
+report bugs:
+    a.t.miedema@st.hanze.nl
+
+"""
+
+from urllib.request import urlopen
+import getopt
+import sys
+import csv
+import re
+import os
+
+settings = dict()
+
+def parseOpt():
+    '''
+    parses commandline arguments and set these as global settings
+    '''
+
+    opts, args = getopt.getopt(sys.argv[1:], 'vo:ht', ['verbose','output=', 'help', 'test' ])
+    for o, a in opts:
+        if o in ('-v', '--verbose'):
+            settings['verbose'] = 1
+        if o in ('-o', '--output'):
+            settings['outputFile'] = a
+        if o in ('-h', '--help'):
+            usage()            
+        if o in ('-t', '--test'):
+            settings['test'] = True
+    return args
+
+def verbose(message):
+    '''
+    prints verbose messages when verbose is enabled
+    '''
+    if settings['verbose'] > 0:
+        print(message)
+
+def usage():
+    ''' 
+    prints usage
+    '''
+    print(__doc__, file = sys.stderr)
+    exit(1)
+
+def setup():
+    '''
+    init setup 
+    '''
+    settings['verbose'] = 0
+    settings['outputFile'] = ""
+    settings['test'] = False
+
+def error(err):
+    '''
+    prints error stream
+    '''
+    print('Het volgende gaat fout:\n{}'.format(err.args), file = sys.stderr)
+    exit(1)
+                        
+def getHeader():
+    header = '''##fileformat=VCFv4.1
+##contig=<ID=Un|NT_113961.1,length=166566>
+##contig=<ID=Un|NT_113923.1,length=186858>
+##contig=<ID=Un|NT_167208.1,length=164239>
+##contig=<ID=Un|NT_167209.1,length=137718>
+##contig=<ID=Un|NT_167210.1,length=172545>
+##contig=<ID=Un|NT_167211.1,length=172294>
+##contig=<ID=Un|NT_167212.1,length=172149>
+##contig=<ID=Un|NT_113889.1,length=161147>
+##contig=<ID=Un|NT_167213.1,length=179198>
+##contig=<ID=Un|NT_167214.1,length=161802>
+##contig=<ID=Un|NT_167215.1,length=155397>
+##contig=<ID=Un|NT_167216.1,length=186861>
+##contig=<ID=Un|NT_167217.1,length=180455>
+##contig=<ID=Un|NT_167218.1,length=179693>
+##contig=<ID=Un|NT_167219.1,length=211173>
+##contig=<ID=Un|NT_167221.1,length=128374>
+##contig=<ID=Un|NT_167222.1,length=129120>
+##contig=<ID=Un|NT_167223.1,length=19913>
+##contig=<ID=Un|NT_167224.1,length=43691>
+##contig=<ID=Un|NT_167225.1,length=27386>
+##contig=<ID=Un|NT_167228.1,length=40531>
+##contig=<ID=Un|NT_167230.1,length=41934>
+##contig=<ID=Un|NT_167232.1,length=39939>
+##contig=<ID=Un|NT_167235.1,length=42152>
+##contig=<ID=Un|NT_167236.1,length=43523>
+##contig=<ID=Un|NT_167237.1,length=43341>
+##contig=<ID=Un|NT_167238.1,length=39929>
+##contig=<ID=Un|NT_167240.1,length=38154>
+##contig=<ID=Un|NT_167220.1,length=15008>
+##contig=<ID=Un|NT_167226.1,length=40652>
+##contig=<ID=Un|NT_167227.1,length=45941>
+##contig=<ID=Un|NT_167229.1,length=34474>
+##contig=<ID=Un|NT_167231.1,length=45867>
+##contig=<ID=Un|NT_167233.1,length=33824>
+##contig=<ID=Un|NT_167234.1,length=41933>
+##contig=<ID=Un|NT_167239.1,length=36651>
+##contig=<ID=Un|NT_167241.1,length=36422>
+##contig=<ID=Un|NT_167242.1,length=39786>
+##contig=<ID=Un|NT_167243.1,length=38502>
+##reference=C:\\Program_Files_(x86)\\SoftGenetics\\NextGENe\\References\\GRCh37
+##contig=<ID=1,length=249240621>
+##contig=<ID=1|NT_113878.1,length=106433>
+##contig=<ID=1|NT_167207.1,length=547496>
+##contig=<ID=2,length=243189373>
+##contig=<ID=3,length=197962430>
+##contig=<ID=4,length=191044276>
+##contig=<ID=4|NT_113885.1,length=189789>
+##contig=<ID=4|NT_113888.1,length=191469>
+##contig=<ID=5,length=180905260>
+##contig=<ID=6,length=171055067>
+##contig=<ID=7,length=159128663>
+##contig=<ID=7|NT_113901.1,length=182896>
+##contig=<ID=8,length=146304022>
+##contig=<ID=8|NT_113909.1,length=38914>
+##contig=<ID=8|NT_113907.1,length=37175>
+##contig=<ID=9,length=141153431>
+##contig=<ID=9|NT_113915.1,length=187035>
+##contig=<ID=9|NT_113911.1,length=36148>
+##contig=<ID=9|NT_113914.1,length=90085>
+##contig=<ID=9|NT_113916.2,length=169874>
+##contig=<ID=10,length=135524747>
+##contig=<ID=11,length=134946516>
+##contig=<ID=11|NT_113921.2,length=40103>
+##contig=<ID=12,length=133841895>
+##contig=<ID=13,length=115109878>
+##contig=<ID=14,length=107289540>
+##contig=<ID=15,length=102521392>
+##contig=<ID=16,length=90294753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=17|NT_113943.1,length=81310>
+##contig=<ID=17|NT_113930.1,length=174588>
+##contig=<ID=17|NT_113941.1,length=37498>
+##contig=<ID=17|NT_113945.1,length=41001>
+##contig=<ID=18,length=78017248>
+##contig=<ID=18|NT_113947.1,length=4262>
+##contig=<ID=19,length=59118983>
+##contig=<ID=19|NT_113949.1,length=159169>
+##contig=<ID=19|NT_113948.1,length=92689>
+##contig=<ID=20,length=62965520>
+##contig=<ID=21,length=48119895>
+##contig=<ID=21|NT_113950.2,length=27682>
+##contig=<ID=22,length=51244566>
+##contig=<ID=X,length=155260560>
+##contig=<ID=Y,length=59363566>
+##contig=<ID=UN|NT_113961.1,length=166566>
+##contig=<ID=UN|NT_113923.1,length=186858>
+##contig=<ID=UN|NT_167208.1,length=164239>
+##contig=<ID=UN|NT_167209.1,length=137718>
+##contig=<ID=UN|NT_167210.1,length=172545>
+##contig=<ID=UN|NT_167211.1,length=172294>
+##contig=<ID=UN|NT_167212.1,length=172149>
+##contig=<ID=UN|NT_113889.1,length=161147>
+##contig=<ID=UN|NT_167213.1,length=179198>
+##contig=<ID=UN|NT_167214.1,length=161802>
+##contig=<ID=UN|NT_167215.1,length=155397>
+##contig=<ID=UN|NT_167216.1,length=186861>
+##contig=<ID=UN|NT_167217.1,length=180455>
+##contig=<ID=UN|NT_167218.1,length=179693>
+##contig=<ID=UN|NT_167219.1,length=211173>
+##contig=<ID=UN|NT_167221.1,length=128374>
+##contig=<ID=UN|NT_167222.1,length=129120>
+##contig=<ID=UN|NT_167223.1,length=19913>
+##contig=<ID=UN|NT_167224.1,length=43691>
+##contig=<ID=UN|NT_167225.1,length=27386>
+##contig=<ID=UN|NT_167228.1,length=40531>
+##contig=<ID=UN|NT_167230.1,length=41934>
+##contig=<ID=UN|NT_167232.1,length=39939>
+##contig=<ID=UN|NT_167235.1,length=42152>
+##contig=<ID=UN|NT_167236.1,length=43523>
+##contig=<ID=UN|NT_167237.1,length=43341>
+##contig=<ID=UN|NT_167238.1,length=39929>
+##contig=<ID=UN|NT_167240.1,length=38154>
+##contig=<ID=UN|NT_167220.1,length=15008>
+##contig=<ID=UN|NT_167226.1,length=40652>
+##contig=<ID=UN|NT_167227.1,length=45941>
+##contig=<ID=UN|NT_167229.1,length=34474>
+##contig=<ID=UN|NT_167231.1,length=45867>
+##contig=<ID=UN|NT_167233.1,length=33824>
+##contig=<ID=UN|NT_167234.1,length=41933>
+##contig=<ID=UN|NT_167239.1,length=36651>
+##contig=<ID=UN|NT_167241.1,length=36422>
+##contig=<ID=UN|NT_167242.1,length=39786>
+##contig=<ID=UN|NT_167243.1,length=38502>
+##contig=<ID=M,length=16569>
+##INFO=<ID=CLINVAR_CLNSIG,Number=.,Type=String,Description="Value representing clinical significant allele 0 means ref 1 means first alt allele etc.">
+##INFO=<ID=CLINVAR_CLNALLE,Number=.,Type=String,Description="Value representing the clinical significanct according to ClinVar">
+##INFO=<ID=GENE_SYMBOL,Number=1,Type=String,Description="HGNC gene symbol">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\t'''
+    return header 
+            
+def inflateAggregates(args):
+    header = getHeader()
+    print(header)
+    for arg in args:
+        
+        try:
+            fileName = arg
+            fh = open(fileName, 'r')
+            
+            csvReader = csv.reader(open(arg), delimiter='\t', quotechar='"')
+            for row in csvReader:
+                
+                if "Position" in row[0]:
+                    
+                    continue
+                   
+                   # header.append( ",".join(str(x) for x in row))
+                    #variant line
+                else:
+                    # we are only interrested in SNPs and non UTR regions
+                    
+                        
+                    ref = getBaseFromOtherStrand(row[3])
+                    alt = getBaseFromOtherStrand(row[4])
+                    chr = row[0]
+                    position = row[1]
+                    info = row[7]
+                    id = row[2]
+                    quality = row[5]
+                    filter = row[6]
+                    
+                    line = chr + "\t" + position + "\t" + id + "\t" + ref + "\t" + alt + "\t" + quality + "\t" + filter + "\t" + info
+                    
+                    print(line)
+
+               #18:21153422-21153422
+            #   18      21153422        .       C       T       .       .       CLINVAR_CLNSIG="Pathogenic";CLINVAR_CLNALLE=1;GENE_SYMBOL=NPC1;
+        except Exception as err:
+            error(err)
+    #header line to print:  print("\n".join(str(x) for x in header))
+
+def getBaseFromOtherStrand(base):
+    if (base == "A"):
+        base = "T"
+    elif (base == "C"):
+        base = "G"
+    elif (base == "G"):
+        base = "C"
+    elif (base =="T"):
+        base = "A"
+    
+    return base
+
+
+def main():
+    setup()
+    args = parseOpt()
+   # if(settings['outputFile'] == ""):
+    #    usage()
+    
+    if(len(args) > 0):
+        inflateAggregates(args)
+
+main()

--- a/gene_based_CADD_score_validator/scripts/python/mvl2vcf.py
+++ b/gene_based_CADD_score_validator/scripts/python/mvl2vcf.py
@@ -1,0 +1,285 @@
+#! /usr/bin/local/python3
+"""
+Author  : Bram Miedema
+Version : 0.1
+date    : 22-September-2015
+
+This script 
+
+This script needs two arguments -o [path_to_output_file]> and a one or more files
+any argument after the options below will be considered file names <two or more vcf batch files to be merged>]
+
+Below is a list of options available:
+    -h [--help] shows this screen
+    -v [--verbose] verbose mode test purpose
+    -o [--output] specifies the output file path and file name e.g /homes/output.vcf
+    -t [--test] enables test run no output file will be created
+
+report bugs:
+    a.t.miedema@st.hanze.nl
+
+"""
+
+from urllib.request import urlopen
+import getopt
+import sys
+import csv
+import re
+import os
+
+settings = dict()
+
+def parseOpt():
+    '''
+    parses commandline arguments and set these as global settings
+    '''
+
+    opts, args = getopt.getopt(sys.argv[1:], 'vo:ht', ['verbose','output=', 'help', 'test' ])
+    for o, a in opts:
+        if o in ('-v', '--verbose'):
+            settings['verbose'] = 1
+        if o in ('-o', '--output'):
+            settings['outputFile'] = a
+        if o in ('-h', '--help'):
+            usage()            
+        if o in ('-t', '--test'):
+            settings['test'] = True
+    return args
+
+def verbose(message):
+    '''
+    prints verbose messages when verbose is enabled
+    '''
+    if settings['verbose'] > 0:
+        print(message)
+
+def usage():
+    ''' 
+    prints usage
+    '''
+    print(__doc__, file = sys.stderr)
+    exit(1)
+
+def setup():
+    '''
+    init setup 
+    '''
+    settings['verbose'] = 0
+    settings['outputFile'] = ""
+    settings['test'] = False
+
+def error(err):
+    '''
+    prints error stream
+    '''
+    print('Het volgende gaat fout:\n{}'.format(err.args), file = sys.stderr)
+    exit(1)
+                        
+def getHeader():
+    header = '''##fileformat=VCFv4.1
+##contig=<ID=Un|NT_113961.1,length=166566>
+##contig=<ID=Un|NT_113923.1,length=186858>
+##contig=<ID=Un|NT_167208.1,length=164239>
+##contig=<ID=Un|NT_167209.1,length=137718>
+##contig=<ID=Un|NT_167210.1,length=172545>
+##contig=<ID=Un|NT_167211.1,length=172294>
+##contig=<ID=Un|NT_167212.1,length=172149>
+##contig=<ID=Un|NT_113889.1,length=161147>
+##contig=<ID=Un|NT_167213.1,length=179198>
+##contig=<ID=Un|NT_167214.1,length=161802>
+##contig=<ID=Un|NT_167215.1,length=155397>
+##contig=<ID=Un|NT_167216.1,length=186861>
+##contig=<ID=Un|NT_167217.1,length=180455>
+##contig=<ID=Un|NT_167218.1,length=179693>
+##contig=<ID=Un|NT_167219.1,length=211173>
+##contig=<ID=Un|NT_167221.1,length=128374>
+##contig=<ID=Un|NT_167222.1,length=129120>
+##contig=<ID=Un|NT_167223.1,length=19913>
+##contig=<ID=Un|NT_167224.1,length=43691>
+##contig=<ID=Un|NT_167225.1,length=27386>
+##contig=<ID=Un|NT_167228.1,length=40531>
+##contig=<ID=Un|NT_167230.1,length=41934>
+##contig=<ID=Un|NT_167232.1,length=39939>
+##contig=<ID=Un|NT_167235.1,length=42152>
+##contig=<ID=Un|NT_167236.1,length=43523>
+##contig=<ID=Un|NT_167237.1,length=43341>
+##contig=<ID=Un|NT_167238.1,length=39929>
+##contig=<ID=Un|NT_167240.1,length=38154>
+##contig=<ID=Un|NT_167220.1,length=15008>
+##contig=<ID=Un|NT_167226.1,length=40652>
+##contig=<ID=Un|NT_167227.1,length=45941>
+##contig=<ID=Un|NT_167229.1,length=34474>
+##contig=<ID=Un|NT_167231.1,length=45867>
+##contig=<ID=Un|NT_167233.1,length=33824>
+##contig=<ID=Un|NT_167234.1,length=41933>
+##contig=<ID=Un|NT_167239.1,length=36651>
+##contig=<ID=Un|NT_167241.1,length=36422>
+##contig=<ID=Un|NT_167242.1,length=39786>
+##contig=<ID=Un|NT_167243.1,length=38502>
+##reference=C:\\Program_Files_(x86)\\SoftGenetics\\NextGENe\\References\\GRCh37
+##contig=<ID=1,length=249240621>
+##contig=<ID=1|NT_113878.1,length=106433>
+##contig=<ID=1|NT_167207.1,length=547496>
+##contig=<ID=2,length=243189373>
+##contig=<ID=3,length=197962430>
+##contig=<ID=4,length=191044276>
+##contig=<ID=4|NT_113885.1,length=189789>
+##contig=<ID=4|NT_113888.1,length=191469>
+##contig=<ID=5,length=180905260>
+##contig=<ID=6,length=171055067>
+##contig=<ID=7,length=159128663>
+##contig=<ID=7|NT_113901.1,length=182896>
+##contig=<ID=8,length=146304022>
+##contig=<ID=8|NT_113909.1,length=38914>
+##contig=<ID=8|NT_113907.1,length=37175>
+##contig=<ID=9,length=141153431>
+##contig=<ID=9|NT_113915.1,length=187035>
+##contig=<ID=9|NT_113911.1,length=36148>
+##contig=<ID=9|NT_113914.1,length=90085>
+##contig=<ID=9|NT_113916.2,length=169874>
+##contig=<ID=10,length=135524747>
+##contig=<ID=11,length=134946516>
+##contig=<ID=11|NT_113921.2,length=40103>
+##contig=<ID=12,length=133841895>
+##contig=<ID=13,length=115109878>
+##contig=<ID=14,length=107289540>
+##contig=<ID=15,length=102521392>
+##contig=<ID=16,length=90294753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=17|NT_113943.1,length=81310>
+##contig=<ID=17|NT_113930.1,length=174588>
+##contig=<ID=17|NT_113941.1,length=37498>
+##contig=<ID=17|NT_113945.1,length=41001>
+##contig=<ID=18,length=78017248>
+##contig=<ID=18|NT_113947.1,length=4262>
+##contig=<ID=19,length=59118983>
+##contig=<ID=19|NT_113949.1,length=159169>
+##contig=<ID=19|NT_113948.1,length=92689>
+##contig=<ID=20,length=62965520>
+##contig=<ID=21,length=48119895>
+##contig=<ID=21|NT_113950.2,length=27682>
+##contig=<ID=22,length=51244566>
+##contig=<ID=X,length=155260560>
+##contig=<ID=Y,length=59363566>
+##contig=<ID=UN|NT_113961.1,length=166566>
+##contig=<ID=UN|NT_113923.1,length=186858>
+##contig=<ID=UN|NT_167208.1,length=164239>
+##contig=<ID=UN|NT_167209.1,length=137718>
+##contig=<ID=UN|NT_167210.1,length=172545>
+##contig=<ID=UN|NT_167211.1,length=172294>
+##contig=<ID=UN|NT_167212.1,length=172149>
+##contig=<ID=UN|NT_113889.1,length=161147>
+##contig=<ID=UN|NT_167213.1,length=179198>
+##contig=<ID=UN|NT_167214.1,length=161802>
+##contig=<ID=UN|NT_167215.1,length=155397>
+##contig=<ID=UN|NT_167216.1,length=186861>
+##contig=<ID=UN|NT_167217.1,length=180455>
+##contig=<ID=UN|NT_167218.1,length=179693>
+##contig=<ID=UN|NT_167219.1,length=211173>
+##contig=<ID=UN|NT_167221.1,length=128374>
+##contig=<ID=UN|NT_167222.1,length=129120>
+##contig=<ID=UN|NT_167223.1,length=19913>
+##contig=<ID=UN|NT_167224.1,length=43691>
+##contig=<ID=UN|NT_167225.1,length=27386>
+##contig=<ID=UN|NT_167228.1,length=40531>
+##contig=<ID=UN|NT_167230.1,length=41934>
+##contig=<ID=UN|NT_167232.1,length=39939>
+##contig=<ID=UN|NT_167235.1,length=42152>
+##contig=<ID=UN|NT_167236.1,length=43523>
+##contig=<ID=UN|NT_167237.1,length=43341>
+##contig=<ID=UN|NT_167238.1,length=39929>
+##contig=<ID=UN|NT_167240.1,length=38154>
+##contig=<ID=UN|NT_167220.1,length=15008>
+##contig=<ID=UN|NT_167226.1,length=40652>
+##contig=<ID=UN|NT_167227.1,length=45941>
+##contig=<ID=UN|NT_167229.1,length=34474>
+##contig=<ID=UN|NT_167231.1,length=45867>
+##contig=<ID=UN|NT_167233.1,length=33824>
+##contig=<ID=UN|NT_167234.1,length=41933>
+##contig=<ID=UN|NT_167239.1,length=36651>
+##contig=<ID=UN|NT_167241.1,length=36422>
+##contig=<ID=UN|NT_167242.1,length=39786>
+##contig=<ID=UN|NT_167243.1,length=38502>
+##contig=<ID=M,length=16569>
+##INFO=<ID=CLINVAR_CLNSIG,Number=.,Type=String,Description="Value representing clinical significant allele 0 means ref 1 means first alt allele etc.">
+##INFO=<ID=CLINVAR_CLNALLE,Number=.,Type=String,Description="Value representing the clinical significanct according to ClinVar">
+##INFO=<ID=GENE_SYMBOL,Number=1,Type=String,Description="HGNC gene symbol">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\t'''
+    return header 
+            
+def inflateAggregates(args):
+    header = getHeader()
+    print(header)
+    for arg in args:
+        try:
+            fileName = arg
+            fh = open(fileName, 'r')
+           
+            csvReader = csv.reader(open(arg), delimiter='\t', quotechar='"')
+            for row in csvReader:
+                
+                if "Position" in row[0]:
+                    
+                    continue
+                   
+                   # header.append( ",".join(str(x) for x in row))
+                    #variant line
+                else:
+                    # we are only interrested in SNPs and non UTR regions
+                    if(((row[4] == "snp") | (row[4] == "SNP")) & ("UTR" not in row[5])):
+                        if(row[9] == "Likely benign"):
+                            clnsig = "CLINVAR_CLNSIG=3"
+                        if(row[9] == "Likely pathogenic"):
+                            clnsig = "CLINVAR_CLNSIG=4"
+                        if(row[9] == "Pathogenic"):
+                            clnsig = "CLINVAR_CLNSIG=5"
+                        
+                        clnsig_all = "CLINVAR_CLNALLE=" + "1"
+                        geneSymbol = "GENE_SYMBOL=" + row[1] 
+                        id = "."
+                        filter = "."
+                        quality = "."
+                        chr = row[0].split(":")[0]
+                        position = int(row[0].split(":")[1])
+                        
+                        isValid = False 
+                        
+                        alleles = row[3].split(">")
+                        ref = alleles[0][len(alleles[0])-1]
+                        # check if variant lies close to an exon +/- 5 bp indicating splice variant
+                        if("+" in row[3]):
+                            validation = row[3].split("+")
+                            
+                            if (int(re.sub('[^0-9]','', validation[1])) <= 5):
+                                isValid= True
+                        elif("-" in row[3]):
+                            validation = row[3].split("-") 
+                            if (int(re.sub('[^0-9]','', validation[1])) <= 5):
+                                isValid= True
+                        # If no + or -  is found we are dealing with a variant in a transcript/coding area
+                        else:
+                            isValid= True
+                            
+                        alt = alleles[1]    
+                     
+                        line = chr + "\t" + str(position)+ "\t" + id + "\t" + ref + "\t" + alt + "\t" + quality + "\t" + filter + "\t" + clnsig.strip() + ";" + clnsig_all + ";"+ geneSymbol.strip()+ ";"
+                        if(isValid):
+                            print(line)
+
+                
+                  
+        except Exception as err:
+            error(err)
+    #header line to print:  print("\n".join(str(x) for x in header))
+        
+
+def main():
+    setup()
+    args = parseOpt()
+   # if(settings['outputFile'] == ""):
+    #    usage()
+    
+    if(len(args) > 0):
+        inflateAggregates(args)
+
+main()


### PR DESCRIPTION
…ipt can be used to determine thresholds given a VCF dataset containing variants with CADD scores, gene symbols and population Allele Frequencies. These variant annotations can be added by using the CMDannotator in the java folder.The python scripts can be used to convert managed variant list variants to vcf, these can then be used as an additional source of relavent variants to be used in the R script.