### PR TITLE
fixing bug when 2 prepare_bed_file scripts are run together

### DIFF
--- a/prepare_NGS_Bedfiles.sh
+++ b/prepare_NGS_Bedfiles.sh
@@ -110,17 +110,9 @@ if [[ -z "${DATA-}" ]]; then
         DATA="chr"
 fi
 if [[ -z "${TMP-}" ]]; then
-	whichHost=$(hostname)
-	if [ "$whichHost" == "zinc-finger.gcc.rug.nl" ]
-	then
-		 TMP="/groups/umcg-gaf/tmp05/tmp"
-	elif [ "$whichHost" == "calculon" ]
-	then
-		TMP="/groups/umcg-gaf/tmp04/tmp"
-	else
-		echo "unknown host!"
-		exit 1
-	fi
+	THISDIR=$(pwd)
+	TMP=${THISDIR}/TMP/
+	mkdir ${TMP}	
 fi
 
 BATCHCOUNT=3
@@ -144,6 +136,7 @@ echo "INTERVALSFOLDER: $INTERVALFOLDER"
 echo "EXTENSION: $EXTENSION"
 echo "REFERENCE: $REFERENCE"
 echo "COVPERBASE: $COVPERBASE"
+echo "TMPDIR: ${TMP}"
 
 MAP="${INTERVALFOLDER}"
 


### PR DESCRIPTION
if the name of the bedfile is the same, then it was writing to the exact same file