### PR TITLE
Bugfix for renameFastQs.bash

### DIFF
--- a/renameFastQs.bash
+++ b/renameFastQs.bash
@@ -274,7 +274,7 @@ fi
 #
 # Check if sequencingStartDate is in the expected format.
 #
-ssd_regex='^[1-9][0-9][0-1][1-9][0-3][0-9]$'
+ssd_regex='^[1-9][0-9][0-1][0-9][0-3][0-9]$'
 if [[ "${sequencingStartDate}" =~ ${ssd_regex} ]]
 then
 	echo "INFO: Using sequencingStartDate ${sequencingStartDate}"


### PR DESCRIPTION
Fixed bug in regex for checking sequencingStartDate that would refuse to except month 10 as valid month.